### PR TITLE
feat: widen spacy requirements

### DIFF
--- a/datahub-classify/setup.py
+++ b/datahub-classify/setup.py
@@ -18,7 +18,7 @@ base_requirements = {
     "schwifty>=2022.9.0",
     "python-stdnum>=1.17",
     "ipaddress>=1.0.23",
-    "spacy>=3.4.1,<=3.5.0",
+    "spacy>=3.4.1,<3.8",
     "phonenumbers>=8.12.56,<=8.13.0",
 }
 


### PR DESCRIPTION
spacy is a large library with many transitive dependencies.  Having a tight bound makes resolving datahub-ingests with wider Python ecosystems difficult.